### PR TITLE
fix: show all models in picker on open

### DIFF
--- a/src/frontend/src/components/ModelPicker.tsx
+++ b/src/frontend/src/components/ModelPicker.tsx
@@ -63,7 +63,7 @@ export function ModelPicker({ provider, value, onChange }: Props) {
           }}
           onFocus={() => {
             setOpen(true)
-            setFilter(value)
+            setFilter('')
           }}
           onKeyDown={e => {
             if (e.key === 'Escape') { setOpen(false); inputRef.current?.blur() }
@@ -87,7 +87,7 @@ export function ModelPicker({ provider, value, onChange }: Props) {
               setOpen(false)
             } else {
               setOpen(true)
-              setFilter(value)
+              setFilter('')
               inputRef.current?.focus()
             }
           }}


### PR DESCRIPTION
## Problem

The model picker dropdown filters its list using the current model name as the initial filter text. When a user opens the picker, only models whose names contain the currently selected model appear, forcing the user to clear the input before they can browse other options. Reported on Discord as a confusing UX.

## Technical Approach

`ModelPicker` initialized `filter` to `value` in both the input's `onFocus` handler and the chevron button's click handler. Changed both call sites to `setFilter('')` so the dropdown opens with no filter applied and all fetched models are visible. Typed-search behavior is unchanged; typing still narrows the list via the existing `filter` state.

## Player-Facing Release Notes

- Model picker now shows all available models when you open the dropdown, instead of pre-filtering by the current model name. You can still type to search.