### PR TITLE
fix: responsive wrapping in main panel header

### DIFF
--- a/src/frontend/src/components/ProfileView.tsx
+++ b/src/frontend/src/components/ProfileView.tsx
@@ -517,7 +517,7 @@ export function ProfileView({ profile, providers, status, playerData, onPlayerDa
   return (
     <div className="flex flex-col h-full">
       {/* Header bar */}
-      <div data-tour="navbar" className="flex items-center gap-3 h-12 px-3.5 bg-card border-b border-border select-none">
+      <div data-tour="navbar" className="flex flex-wrap items-center gap-x-3 gap-y-1.5 min-h-12 py-1.5 px-3.5 bg-card border-b border-border select-none">
         {onToggleProfileList && (
           <button
             onClick={onToggleProfileList}
@@ -807,7 +807,7 @@ export function ProfileView({ profile, providers, status, playerData, onPlayerDa
             size="sm"
             onClick={handleConnect}
             disabled={connecting}
-            className="gap-1.5 font-semibold text-[hsl(var(--smui-green))] border-[hsl(var(--smui-green)/0.4)] hover:bg-[hsl(var(--smui-green)/0.1)]"
+            className="shrink-0 gap-1.5 font-semibold text-[hsl(var(--smui-green))] border-[hsl(var(--smui-green)/0.4)] hover:bg-[hsl(var(--smui-green)/0.1)]"
           >
             {connecting ? <PlugZap size={12} className="animate-pulse" /> : <Plug size={12} />}
             {connecting ? 'Connecting...' : (isManual ? 'Connect' : 'Connect + Start')}
@@ -817,14 +817,14 @@ export function ProfileView({ profile, providers, status, playerData, onPlayerDa
             variant="outline"
             size="sm"
             onClick={handleDisconnect}
-            className="gap-1.5 font-semibold text-destructive border-destructive/40 hover:bg-destructive/10"
+            className="shrink-0 gap-1.5 font-semibold text-destructive border-destructive/40 hover:bg-destructive/10"
           >
             <Square size={12} />
             Disconnect
           </Button>
         )}
 
-        <Button variant="ghost" size="icon" onClick={() => { if (window.confirm('Delete this profile and all its logs?')) onDelete() }} className="h-7 w-7 text-muted-foreground hover:text-destructive ml-1">
+        <Button variant="ghost" size="icon" onClick={() => { if (window.confirm('Delete this profile and all its logs?')) onDelete() }} className="shrink-0 h-7 w-7 text-muted-foreground hover:text-destructive ml-1">
           <Trash2 size={14} />
         </Button>
       </div>


### PR DESCRIPTION
## Problem

When the browser is resized narrow, the Admiral main-panel header (navbar) overflows horizontally: the Connect / Disconnect and Delete buttons slide off the edge instead of wrapping, shrinking, or eliding. The Directive row one line below already behaves correctly because it uses `truncate flex-1 min-w-0` with `shrink-0` siblings.

The navbar itself was declared as a non-wrapping flex row with a fixed `h-12`, and the action buttons had no `shrink-0`, so there was nowhere for overflow content to go.

## Technical Approach

In `src/frontend/src/components/ProfileView.tsx`:

- Change the navbar container from `flex items-center gap-3 h-12` to `flex flex-wrap items-center gap-x-3 gap-y-1.5 min-h-12 py-1.5`. The row still reads as a single line at wide widths, but can now reflow and grow vertically when space is tight.
- Add `shrink-0` to the Connect, Disconnect, and Delete buttons so their labels/icons are preserved as siblings compress.

This matches the pattern already used successfully in the Directive section of the same component.

## Player-Facing Release Notes

- Admiral: the top bar of the main panel now wraps gracefully when the window is narrow instead of pushing the Connect/Disconnect and Delete buttons off-screen.