### PR TITLE
fix: reject malformed LLM tool calls with empty names

### DIFF
--- a/src/server/lib/loop.ts
+++ b/src/server/lib/loop.ts
@@ -159,10 +159,40 @@ export async function runAgentTurn(
     for (const toolCall of toolCalls) {
       if (options?.signal?.aborted) return
 
-      options?.onActivity?.(`Executing tool: ${toolCall.name}`)
+      // Guard against malformed tool calls from LLMs (e.g. empty name, null args).
+      // Some local/small models occasionally emit tool-use blocks with no name,
+      // which would otherwise fail confusingly deep in tool dispatch.
+      const rawName = typeof toolCall.name === 'string' ? toolCall.name : ''
+      const name = rawName.trim()
+      if (!name) {
+        const errMsg = 'Error: LLM produced malformed tool call with empty name - skipping'
+        log('error', errMsg, JSON.stringify({
+          toolCallId: toolCall.id,
+          name: toolCall.name,
+          arguments: toolCall.arguments,
+        }, null, 2))
+        const toolResultMessage: Message = {
+          role: 'toolResult',
+          toolCallId: toolCall.id,
+          toolName: rawName || '(empty)',
+          content: [{ type: 'text', text: errMsg }],
+          isError: true,
+          timestamp: Date.now(),
+        }
+        context.messages.push(toolResultMessage)
+        continue
+      }
+
+      // Normalize arguments: LLMs sometimes emit null/undefined instead of {}.
+      const safeArgs: Record<string, unknown> =
+        toolCall.arguments && typeof toolCall.arguments === 'object'
+          ? toolCall.arguments as Record<string, unknown>
+          : {}
+
+      options?.onActivity?.(`Executing tool: ${name}`)
       const callReason = !showedReason ? reason : undefined
       showedReason = true
-      const result = await executeTool(toolCall.name, toolCall.arguments, toolCtx, callReason)
+      const result = await executeTool(name, safeArgs, toolCtx, callReason)
 
       // If update_todo changed the todo via local tool, sync back
       todo.value = toolCtx.todo
@@ -171,7 +201,7 @@ export async function runAgentTurn(
       const toolResultMessage: Message = {
         role: 'toolResult',
         toolCallId: toolCall.id,
-        toolName: toolCall.name,
+        toolName: name,
         content: [{ type: 'text', text: result }],
         isError,
         timestamp: Date.now(),

--- a/src/server/lib/tools.ts
+++ b/src/server/lib/tools.ts
@@ -67,6 +67,17 @@ export async function executeTool(
   ctx: ToolContext,
   reason?: string,
 ): Promise<string> {
+  // Defense in depth: callers should already have validated the name, but
+  // guard here too so a malformed LLM tool call never reaches dispatch.
+  if (typeof name !== 'string' || !name.trim()) {
+    const errMsg = 'Error: LLM produced malformed tool call with empty name - skipping'
+    ctx.log('error', errMsg)
+    return errMsg
+  }
+  // Normalize args to an object so downstream code can rely on Object.keys/entries.
+  if (!args || typeof args !== 'object') {
+    args = {}
+  }
   if (LOCAL_TOOLS.has(name)) {
     ctx.log('tool_call', `${name}(${formatArgs(args)})`)
     return executeLocalTool(name, args, ctx)


### PR DESCRIPTION
## Problem

A Discord-reported bug surfaced a log line like `tool: ({})` - a local LLM had emitted a tool-use block with an empty `name` (and empty/null arguments). Admiral passed this straight into `executeTool`, which then failed deep in dispatch with a confusing error instead of gracefully rejecting the malformed call.

## Technical Approach

Validation is now done at two layers (defense in depth):

1. **Agent loop (`src/server/lib/loop.ts`)** - Before executing each tool call, check that `toolCall.name` is a non-empty string. If not, log a warning, push a `toolResult` error message back into the context (so the LLM can recover and retry), and skip to the next tool call. Also normalize `toolCall.arguments` to `{}` when null/undefined.
2. **Tool dispatcher (`src/server/lib/tools.ts`)** - `executeTool` itself now guards against empty names and null args, returning an `Error: LLM produced malformed tool call with empty name - skipping` string rather than crashing.

The result message keeps the same `toolCallId` so the LLM's tool_use block is properly answered and the turn can continue normally.

## Player-Facing Release Notes

- Admiral no longer crashes or produces confusing errors when a local/small LLM emits a tool call with an empty name. The bad call is now logged and skipped, and the agent keeps running.