### PR TITLE
fix: refresh agent stats panel when Quick Status runs get_status

### DIFF
--- a/src/frontend/src/components/ProfileView.tsx
+++ b/src/frontend/src/components/ProfileView.tsx
@@ -512,7 +512,7 @@ export function ProfileView({ profile, providers, status, playerData, onPlayerDa
     } catch {
       // Error logged by agent
     }
-  }, [profile.id])
+  }, [profile.id, onPlayerData])
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## Problem / Motivation

The Quick "Status" button in Admiral's profile view sends `get_status` to the server and receives a valid response, but the agent stats panel silently fails to update. Other paths that call `get_status` (like the `fetchStatus` effect) work fine.

## Technical Approach

In `ProfileView.tsx`, the `useCallback` wrapping `handleSendCommand` had `[profile.id]` as its dependency array but called `onPlayerData(...)` inside. The callback captured a stale `onPlayerData` reference from the first render and kept invoking it forever. Added `onPlayerData` to the deps so the callback rebuilds when the parent rotates its setter.

`fetchStatus` (line 364) already had correct deps; no change needed there.

## Reporter credit

Reported by @rsned in Discord bug-reports thread 1486999105350930492.