### PR TITLE
fix: keep status panel auto-refresh alive (stabilize onPlayerData)

### DIFF
--- a/src/frontend/src/components/Dashboard.tsx
+++ b/src/frontend/src/components/Dashboard.tsx
@@ -66,6 +66,16 @@ export function Dashboard({ profiles: initialProfiles, providers, registrationCo
     return () => clearInterval(interval)
   }, [])
 
+  // Stable per-active-profile player-data setter. Keyed on the primitive
+  // activeId (not the activeProfile object) so its identity survives the 5s
+  // status poll's re-renders. An unstable closure here would invalidate
+  // ProfileView's fetchStatus on every poll, which tore down and rescheduled
+  // the 60s status-refresh interval before it could ever fire.
+  const handlePlayerData = useCallback((data: Record<string, unknown>) => {
+    if (!activeId) return
+    setPlayerDataMap(prev => ({ ...prev, [activeId]: data }))
+  }, [activeId])
+
   const refreshProfiles = useCallback(async () => {
     try {
       const resp = await fetch('/api/profiles')
@@ -182,7 +192,7 @@ export function Dashboard({ profiles: initialProfiles, providers, registrationCo
               status={statuses[activeProfile.id] || { connected: false, running: false, paused: false }}
               registrationCode={registrationCode}
               playerData={playerDataMap[activeProfile.id] || null}
-              onPlayerData={(data) => setPlayerDataMap(prev => ({ ...prev, [activeProfile.id]: data }))}
+              onPlayerData={handlePlayerData}
               onDelete={() => handleDeleteProfile(activeProfile.id)}
               onRefresh={() => {
                 refreshProfiles()


### PR DESCRIPTION
## Problem

The Admiral status panel's auto-refresh silently stopped working: player data went stale and only updated on a manual Quick Status click. This was most visible in LLM provider mode, where the agent's own `get_status` calls don't push to the panel, so the panel relied entirely on the (broken) auto-refresh.

Root cause: `Dashboard` polls `/api/profiles` every 5s (`setProfiles`/`setStatuses`), re-rendering on each poll. The inline `onPlayerData` closure changed identity on every render, which invalidated `ProfileView`'s `fetchStatus` `useCallback` (deps `[profile.id, onPlayerData]`). That in turn made the 60s status-poll effect (deps `[status.connected, fetchStatus]`) tear down and reschedule its `setInterval` every 5s — so it never reached 60s and never fired. The 1.5s on-connect timeout had the same fate.

This is distinct from the April dep-array fix (`handleSendCommand` now correctly includes `onPlayerData`), which is already present; that fix addressed the manual button, not the auto-refresh timers.

## Approach

Stabilize `onPlayerData` with a `useCallback` keyed on the primitive `activeId` (which is stable across the 5s poll, since the poll never touches `searchParams`). With `onPlayerData` stable, `fetchStatus` is stable, the 60s interval and 1.5s timeout survive, and the panel auto-refreshes again.

Verified: frontend `tsc --noEmit` clean, `vite build` clean, `bun test` 11/11 pass. Adversarial review confirmed `activeId` stability and no regression in per-profile data routing.

## Player-Facing Release Notes

- Fixed the agent status panel not auto-refreshing — player stats (hull, shield, fuel, location) now update on their own again instead of only when you click Quick Status, especially while an agent is running in LLM mode.
