### PR TITLE
Maintenance pass: log retention, dependency refresh, typecheck + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "./admiral"
   },
   "dependencies": {
-    "@mariozechner/pi-ai": "latest",
+    "@mariozechner/pi-ai": "^0.73.1",
+    "@opentelemetry/api": "^1.9.1",
     "@tanstack/react-virtual": "^3.13.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "concurrently -n server,vite -c blue,magenta \"bun run src/server/index.ts\" \"cd src/frontend && bunx vite dev --port 3030\"",
     "build": "bun run scripts/build.ts",
-    "start": "./admiral"
+    "start": "./admiral",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p src/frontend/tsconfig.json",
+    "test": "bun test"
   },
   "dependencies": {
     "@mariozechner/pi-ai": "^0.73.1",
@@ -25,6 +27,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.0",
     "@tailwindcss/vite": "^4.2.0",
+    "@types/bun": "^1.3.14",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/server/lib/agent-manager.ts
+++ b/src/server/lib/agent-manager.ts
@@ -22,10 +22,9 @@ type SlimGameState = {
 
 function slimGameState(raw: Record<string, unknown> | null): SlimGameState {
   if (!raw) return null
-  const gs = raw as Record<string, Record<string, unknown> & { cargo?: unknown[]; current_ammo?: unknown; magazine_size?: unknown }>
-  const player = gs.player as Record<string, unknown> | undefined
-  const ship = gs.ship as Record<string, unknown> & { cargo?: unknown[] } | undefined
-  const modules = gs.modules as Array<Record<string, unknown>> | undefined
+  const player = raw.player as Record<string, unknown> | undefined
+  const ship = raw.ship as (Record<string, unknown> & { cargo?: unknown[] }) | undefined
+  const modules = raw.modules as Array<Record<string, unknown> & { current_ammo?: unknown; magazine_size?: unknown }> | undefined
   return {
     credits: player?.credits,
     system: player?.current_system,

--- a/src/server/lib/connections/http.ts
+++ b/src/server/lib/connections/http.ts
@@ -149,7 +149,7 @@ export class HttpConnection implements GameConnection {
         })
         if (!resp.ok) throw new Error(`Failed to create session: ${resp.status}`)
 
-        const data = await resp.json()
+        const data = await resp.json() as { session?: ApiSession }
         if (data.session) {
           this.session = data.session
         } else {
@@ -194,9 +194,9 @@ export class HttpConnection implements GameConnection {
     }
 
     try {
-      const data = await resp.json()
+      const data = await resp.json() as CommandResult & { session?: ApiSession }
       if (data.session) this.session = data.session
-      return data as CommandResult
+      return data
     } catch {
       return { error: { code: 'http_error', message: `HTTP ${resp.status}` } }
     }

--- a/src/server/lib/connections/http_v2.ts
+++ b/src/server/lib/connections/http_v2.ts
@@ -226,7 +226,7 @@ export class HttpV2Connection implements GameConnection {
         })
         if (!resp.ok) throw new Error(`Failed to create session: ${resp.status}`)
 
-        const data = await resp.json()
+        const data = await resp.json() as { session?: ApiSession }
         if (data.session) {
           this.session = data.session
         } else {
@@ -280,12 +280,12 @@ export class HttpV2Connection implements GameConnection {
     }
 
     try {
-      const data = await resp.json()
+      const data = await resp.json() as CommandResult & { session?: ApiSession }
       if (data.session) this.session = data.session
       // v2 returns { result: <rendered text>, structuredContent: <JSON> }
       // Keep both: result (text) goes to the LLM, structuredContent is used
       // for cacheGameState and player data display.
-      return data as CommandResult
+      return data
     } catch {
       return { error: { code: 'http_error', message: `HTTP ${resp.status}` } }
     }

--- a/src/server/lib/connections/mcp.ts
+++ b/src/server/lib/connections/mcp.ts
@@ -160,7 +160,7 @@ export class McpConnection implements GameConnection {
       return { error: { message: 'No matching response in SSE stream' } }
     }
 
-    return await resp.json()
+    return await resp.json() as { result?: unknown; error?: { code?: number; message: string } }
   }
 
   private async sendNotification(method: string, params: unknown): Promise<void> {

--- a/src/server/lib/db.ts
+++ b/src/server/lib/db.ts
@@ -192,11 +192,29 @@ export function deleteProfile(id: string): void {
 
 // --- Log CRUD ---
 
+// Every LLM call, tool call, and server response gets logged here with no
+// other cap, so admiral.db grows unbounded over a long-running agent
+// (reported: 18GB). Trim old rows past this cap, checked probabilistically
+// on insert so we're not running a DELETE on every single log write.
+const LOG_ENTRY_CAP_PER_PROFILE = 20_000
+const LOG_TRIM_CHECK_INTERVAL = 200
+
 export function addLogEntry(profileId: string, type: string, summary: string, detail?: string): number {
-  const result = getDb().query(
+  const db = getDb()
+  const result = db.query(
     'INSERT INTO log_entries (profile_id, type, summary, detail) VALUES (?, ?, ?, ?)'
   ).run(profileId, type, summary, detail ?? null)
-  return Number(result.lastInsertRowid)
+  const id = Number(result.lastInsertRowid)
+  if (id % LOG_TRIM_CHECK_INTERVAL === 0) trimLogEntries(profileId)
+  return id
+}
+
+function trimLogEntries(profileId: string): void {
+  getDb().query(
+    `DELETE FROM log_entries WHERE profile_id = ? AND id NOT IN (
+       SELECT id FROM log_entries WHERE profile_id = ? ORDER BY id DESC LIMIT ?
+     )`
+  ).run(profileId, profileId, LOG_ENTRY_CAP_PER_PROFILE)
 }
 
 export function getLogEntries(profileId: string, afterId?: number, limit: number = 100): LogEntry[] {

--- a/src/server/lib/db.ts
+++ b/src/server/lib/db.ts
@@ -1,4 +1,5 @@
 import { Database } from 'bun:sqlite'
+import type { SQLQueryBindings } from 'bun:sqlite'
 import path from 'path'
 import fs from 'fs'
 import type { Provider, Profile, LogEntry } from '../../shared/types'
@@ -182,7 +183,7 @@ export function updateProfile(id: string, updates: Partial<Profile>): Profile | 
   sets.push("updated_at = datetime('now')")
   vals.push(id)
 
-  getDb().query(`UPDATE profiles SET ${sets.join(', ')} WHERE id = ?`).run(...vals)
+  getDb().query(`UPDATE profiles SET ${sets.join(', ')} WHERE id = ?`).run(...(vals as SQLQueryBindings[]))
   return getProfile(id)
 }
 

--- a/src/server/lib/schema.ts
+++ b/src/server/lib/schema.ts
@@ -42,7 +42,7 @@ export async function fetchOpenApiSpec(
       }
       throw new Error(`HTTP ${resp.status}`)
     }
-    const spec = await resp.json()
+    const spec = await resp.json() as Record<string, unknown>
     // Cache on success
     try {
       setPreference(cacheKey, JSON.stringify(spec))

--- a/src/server/routes/logs.ts
+++ b/src/server/routes/logs.ts
@@ -58,7 +58,7 @@ logs.get('/:id/logs', async (c) => {
     // Heartbeat - must be well under the Bun.serve idleTimeout (120s)
     const heartbeat = setInterval(() => {
       if (closed) { clearInterval(heartbeat); return }
-      stream.writeSSE({ data: '', comment: 'heartbeat' }).catch(() => { closed = true })
+      stream.writeSSE({ data: '' }).catch(() => { closed = true })
     }, 30000)
 
     // Keep the stream open until client disconnects

--- a/src/server/routes/models.ts
+++ b/src/server/routes/models.ts
@@ -90,7 +90,7 @@ async function fetchOllamaModels(baseUrl?: string): Promise<string[]> {
   try {
     const resp = await fetch(`${base}/api/tags`, { signal: AbortSignal.timeout(5000) })
     if (!resp.ok) return []
-    const data = await resp.json()
+    const data = await resp.json() as Record<string, unknown>
     const modelList = data.models as { name: string }[] | undefined
     return (modelList || []).map(m => m.name).sort()
   } catch {
@@ -105,7 +105,7 @@ async function fetchOpenAICompatModels(apiUrl: string, apiKey?: string): Promise
 
     const resp = await fetch(apiUrl, { headers, signal: AbortSignal.timeout(10000) })
     if (!resp.ok) return []
-    const data = await resp.json()
+    const data = await resp.json() as Record<string, unknown>
     const modelList = data.data as { id: string }[] | undefined
     return (modelList || []).map(m => m.id).sort()
   } catch {


### PR DESCRIPTION
## Summary

Admiral hadn't had a real maintenance pass in a while (last release published Feb 27; last two commits on main were April 22 and June 27). This does the quick, high-value cleanup identified from a fresh audit against the current gameserver API and admiral's own open issues:

- **fix: prune old log entries to stop unbounded admiral.db growth** — `log_entries` had no retention policy, only a manual per-profile "clear log" route. A long-running agent logs every LLM call/tool call/response forever (reported: 18GB db in #5). Caps each profile to its most recent 20,000 entries, trimmed opportunistically every ~200 inserts. Verified manually: 21,000 inserts → exactly the newest 20,000 rows remain.
- **chore: bump `@mariozechner/pi-ai` to 0.73.1** — was pinned to `"latest"` but the lockfile had it stuck at 0.55.1 (18 minor versions behind), so the model picker was missing every Claude model newer than opus-4-6/sonnet-4-6. Pinned to a real caret range instead of `"latest"` so future bumps are deliberate. This pulled in the Mistral SDK, which has an optional `@opentelemetry/api` peer import that `bun build --compile` resolves statically regardless of the "optional" flag — added it as an explicit dependency so the production build doesn't break.
- **chore: add `@types/bun`, fix `tsc` errors, add PR CI** — `tsc --noEmit` failed out of the box on a fresh clone (no `@types/bun`, so `bun:sqlite`/`bun:test`/`ImportMeta.dir` didn't resolve), and there was no CI beyond the tag-triggered release build — nothing would have caught the `@opentelemetry/api` build break above before it hit a tagged release. Added `@types/bun`, fixed the several real `unknown`-typed `resp.json()` results it uncovered plus a couple of other latent typing bugs, added `typecheck`/`test` package.json scripts, and added `.github/workflows/ci.yml` running typecheck + test + build on every PR.

Also as part of this pass (already landed on `main` directly, included here for context):
- Merged #16 (external contribution) fixing MCP v2 plain-text responses getting YAML-escaped before reaching the LLM.
- Closed #3 (`view_storage` v2 routing collision) as no-longer-reproducible — gameserver has since consolidated storage into a single `spacemolt_storage` tool with a `target` param, so the old path collision this described no longer exists.

## Technical Approach

See commit messages for detail on each change; each commit is independently reviewable.

## Test Plan

- [x] `bun test` — 15/15 passing
- [x] `bun run typecheck` — clean (root + frontend)
- [x] `bun run build` — production binary builds and the frontend bundles successfully
- [x] Manually verified log-entry trimming behavior against a scratch SQLite db (21k inserts → 20k rows retained, newest kept)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KFrt3tgzvhPZuhuVPxuVN2)_